### PR TITLE
Move MyNewPipe out of main app component

### DIFF
--- a/src/app/ang2.ts
+++ b/src/app/ang2.ts
@@ -1,7 +1,6 @@
 import {Component} from 'angular2/core';
 import {RouteConfig, ROUTER_DIRECTIVES} from 'angular2/router';
 import {MyNewComponent} from './components/my-new-component/my-new-component';
-import {MyNewPipe} from './pipes/my-new-pipe/my-new-pipe';
 
 
 @Component({
@@ -9,7 +8,7 @@ import {MyNewPipe} from './pipes/my-new-pipe/my-new-pipe';
   providers: [],
   templateUrl: 'app/ang2.html',
   directives: [ROUTER_DIRECTIVES],
-  pipes: [MyNewPipe]
+  pipes: []
 })
 @RouteConfig([
   {path: '/', name: 'Foo', component: MyNewComponent},

--- a/src/app/components/my-new-component/my-new-component.ts
+++ b/src/app/components/my-new-component/my-new-component.ts
@@ -1,4 +1,5 @@
 import {Component} from 'angular2/core';
+import {MyNewPipe} from '../../pipes/my-new-pipe/my-new-pipe';
 
 
 @Component({
@@ -7,7 +8,7 @@ import {Component} from 'angular2/core';
   styleUrls: ['app/components/my-new-component/my-new-component.css'],
   providers: [],
   directives: [],
-  pipes: []
+  pipes: [MyNewPipe]
 })
 export class MyNewComponent {
 


### PR DESCRIPTION
Move MyNewPipe out of main app component in favor of using it in specific components that will use it (or, in this case, plan to use it).

(Don't pollute root components)
